### PR TITLE
Add Commodities kontainer type

### DIFF
--- a/Content/GameData/GrimmAerospace/GrimmModlets/B9TankTypes/USIB9TankTypes.cfg
+++ b/Content/GameData/GrimmAerospace/GrimmModlets/B9TankTypes/USIB9TankTypes.cfg
@@ -96,7 +96,7 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch,CommunityResourcePack]
 	}
 }
 
-// USILS: Supplies, Mulch
+// USILS: Supplies
 B9_TANK_TYPE:NEEDS[B9PartSwitch,USILifeSupport]
 {
 	name = USISupplies
@@ -106,16 +106,8 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch,USILifeSupport]
 	RESOURCE 
 	{
 		name = Supplies
-		unitsPerVolume = 4.75
+		unitsPerVolume = 5
 	}
-	
-		RESOURCE 
-	{
-		name = Mulch
-		unitsPerVolume = 0.25
-		percentFilled = 0
-	}
-
 }
 
 

--- a/Content/GameData/GrimmAerospace/GrimmModlets/B9TankTypes/USIB9TankTypes.cfg
+++ b/Content/GameData/GrimmAerospace/GrimmModlets/B9TankTypes/USIB9TankTypes.cfg
@@ -97,7 +97,7 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch,CommunityResourcePack]
 }
 
 // USILS: Supplies, Mulch
-B9_TANK_TYPE:NEEDS[B9PartSwitch,USILifeSupport]
+B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/LifeSupport]
 {
 	name = USISuppliesMulch
 	primaryColor = blue
@@ -210,20 +210,26 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch,USILifeSupport,Karbonite]
 	}
 }
 
-// USI?: Commodities - never used??
-//B9_TANK_TYPE:NEEDS[B9PartSwitch] //?
-//{
-//	name = USICommodities
-//	title = Commodities // TODO LOC
-//  primaryColor = Apricot // TODO
-//  secondaryColor = Apricot // TODO
+// USI?: Commodities - RareMetals and ExoticMinerals
+B9_TANK_TYPE:NEEDS[B9PartSwitch,CommunityResourcePack]
+{
+  name = USICommodities
+  title = Commodities
+  primaryColor = Apricot
+  secondaryColor = Apricot
 
-//	RESOURCE
-//	{
-//		name = Commodities
-//		unitsPerVolume = 2.5
-//	}
-//}
+	RESOURCE
+	{
+		name = RareMetals
+		unitsPerVolume = 2.5
+	}
+
+	RESOURCE
+	{
+		name = ExoticMinerals
+		unitsPerVolume = 2.5
+	}
+}
 
 // CRP/USI: MaterialKits
 B9_TANK_TYPE:NEEDS[B9PartSwitch,CommunityResourcePack]
@@ -703,7 +709,7 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/MKS]
 }
 
 // MKS: Refine Water (Kar)
-B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/MKS]
+B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/MKS,UmbraSpaceIndustries/Karbonite]
 {
 	name = USIMKSRefineWaterKar
 	primaryColor = blue
@@ -774,6 +780,445 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/MKS]
 	name = USIMKSRefineFertilizerG
 	primaryColor = ResourceColorOre
 	secondaryColor = ResourceColorOre
+	{
+		name = Gypsum
+		unitsPerVolume = 4.18
+		percentFilled = 0
+	}
+	
+	RESOURCE 
+	{
+		name = Fertilizer
+		unitsPerVolume = 2.09
+		percentFilled = 0
+	}
+}
+
+// MKS: Refine Fertilizer (M)
+B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/MKS]
+{
+	name = USIMKSRefineFertilizerM
+	primaryColor = ResourceColorOre
+	secondaryColor = ResourceColorOre
+	
+	RESOURCE 
+	{
+		name = Minerals
+		unitsPerVolume = 5
+		percentFilled = 0
+	}
+	
+	RESOURCE 
+	{
+		name = Fertilizer
+		unitsPerVolume = 1
+		percentFilled = 0
+	}
+}
+
+// MKS: Refine Metals
+B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/MKS]
+{
+	name = USIMKSRefineMetals
+	primaryColor = grey
+	secondaryColor = grey
+	
+	RESOURCE 
+	{
+		name = MetallicOre
+		unitsPerVolume = 5
+		percentFilled = 0
+	}
+	
+	RESOURCE 
+	{
+		name = Metals
+		unitsPerVolume = 1
+		percentFilled = 0
+	}
+}
+
+// MKS: Refine LFO
+B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/MKS]
+{
+	name = USIMKSRefineLFO
+	primaryColor = ResourceColorLiquidFuel
+	secondaryColor = ResourceColorOxidizer
+	
+	RESOURCE 
+	{
+		name = Ore
+		unitsPerVolume = 5
+		percentFilled = 0
+	}
+	
+	RESOURCE 
+	{
+		name = LiquidFuel
+		unitsPerVolume = 0.45
+		percentFilled = 0
+	}
+
+		RESOURCE 
+	{
+		name = Oxidizer
+		unitsPerVolume = 0.55
+		percentFilled = 0
+	}
+}
+
+// MKS: Refine LiquidFuel
+B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/MKS]
+{
+	name = USIMKSRefineLiquidFuel
+	primaryColor = ResourceColorLiquidFuel
+	secondaryColor = ResourceColorLiquidFuel
+	
+	RESOURCE 
+	{
+		name = Ore
+		unitsPerVolume = 5
+		percentFilled = 0
+	}
+	
+	RESOURCE 
+	{
+		name = LiquidFuel
+		unitsPerVolume = 1
+		percentFilled = 0
+	}
+}
+
+// MKS: Refine MonoPropellant
+B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/MKS]
+{
+	name = USIMKSRefineMonoPropellant
+	primaryColor = ResourceColorMonoPropellant
+	secondaryColor = ResourceColorMonoPropellant
+	
+	RESOURCE 
+	{
+		name = Ore
+		unitsPerVolume = 5
+		percentFilled = 0
+	}
+	
+	RESOURCE 
+	{
+		name = MonoPropellant
+		unitsPerVolume = 1
+		percentFilled = 0
+	}
+}
+
+// MKS: Assemble SpecializedParts
+B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/MKS]
+{
+	name = USIMKSAssembleSpecializedParts
+	primaryColor = black
+	secondaryColor = black
+	
+	RESOURCE 
+	{
+		name = RefinedExotics
+		unitsPerVolume = 0.4
+		percentFilled = 0
+	}
+	
+	RESOURCE 
+	{
+		name = Silicon
+		unitsPerVolume = 4
+		percentFilled = 0
+	}
+
+	RESOURCE 
+	{
+		name = SpecializedParts
+		unitsPerVolume = 2
+		percentFilled = 0
+	}
+}
+
+// MKS: Assemble MaterialKits
+B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/MKS]
+{
+	name = USIMKSAssembleMaterialKits
+	primaryColor = black
+	secondaryColor = black
+	
+	RESOURCE 
+	{
+		name = Metals
+		unitsPerVolume = 1.3
+		percentFilled = 0
+	}
+	
+	RESOURCE 
+	{
+		name = Polymers
+		unitsPerVolume = 1.3
+		percentFilled = 0
+	}
+
+	RESOURCE 
+	{
+		name = Chemicals
+		unitsPerVolume = 0.65
+		percentFilled = 0
+	}
+
+	RESOURCE 
+	{
+		name = MaterialKits
+		unitsPerVolume = 3.2
+		percentFilled = 0
+	}
+}
+
+// MKS:  Assemble Organics (S)
+B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/MKS]
+{
+	name = USIMKSAssembleOrganicsS
+	primaryColor = green
+	secondaryColor = green
+	
+	RESOURCE 
+	{
+		name = Substrate
+		unitsPerVolume = 3
+		percentFilled = 0
+	}
+	
+	RESOURCE 
+	{
+		name = Water
+		unitsPerVolume = 3
+		percentFilled = 0
+	}
+
+	RESOURCE 
+	{
+		name = Organics
+		unitsPerVolume = 0.8
+		percentFilled = 0
+	}
+
+	RESOURCE 
+	{
+		name = Fertilizer
+		unitsPerVolume = 0.1
+		percentFilled = 0
+	}
+}
+
+// MKS:  Assemble Organics (D)
+B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/MKS]
+{
+	name = USIMKSAssembleOrganicsD
+	primaryColor = green
+	secondaryColor = green
+	
+	RESOURCE 
+	{
+		name = Dirt
+		unitsPerVolume = 3
+		percentFilled = 0
+	}
+	
+	RESOURCE 
+	{
+		name = Water
+		unitsPerVolume = 3
+		percentFilled = 0
+	}
+
+	RESOURCE 
+	{
+		name = Organics
+		unitsPerVolume = 0.5
+		percentFilled = 0
+	}
+
+	RESOURCE 
+	{
+		name = Fertilizer
+		unitsPerVolume = 0.1
+		percentFilled = 0
+	}
+}
+
+// MKS:  Assemble ColonySupplies
+B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/MKS]
+{
+	name = USIMKSAssembleColonySupplies
+	primaryColor = green
+	secondaryColor = green
+	
+	RESOURCE 
+	{
+		name = Organics
+		unitsPerVolume = 2
+		percentFilled = 0
+	}
+	
+	RESOURCE 
+	{
+		name = SpecializedParts
+		unitsPerVolume = 0.65
+		percentFilled = 0
+	}
+
+	RESOURCE 
+	{
+		name = MaterialKits
+		unitsPerVolume = 0.65
+		percentFilled = 0
+	}
+
+	RESOURCE 
+	{
+		name = ColonySupplies
+		unitsPerVolume = 3
+		percentFilled = 0
+	}
+}
+
+// MKS: Assemble Machinery
+B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/MKS]
+{
+	name = USIMKSAssembleMachinery
+	primaryColor = black
+	secondaryColor = black
+	
+	RESOURCE 
+	{
+		name = SpecializedParts
+		unitsPerVolume = 0.6
+		percentFilled = 0
+	}
+	
+	RESOURCE 
+	{
+		name = MaterialKits
+		unitsPerVolume = 2.6
+		percentFilled = 0
+	}
+
+	RESOURCE 
+	{
+		name = Machinery
+		unitsPerVolume = 3.2
+		percentFilled = 0
+	}
+}
+
+// MKS: Recycling
+B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/MKS]
+{
+	name = USIMKSRecycling
+	primaryColor = green
+	secondaryColor = white
+	
+	RESOURCE 
+	{
+		name = Recyclables
+		unitsPerVolume = 3.2
+		percentFilled = 0
+	}
+	
+	RESOURCE 
+	{
+		name = Metals
+		unitsPerVolume = 0.65
+		percentFilled = 0
+	}
+
+	RESOURCE 
+	{
+		name = Polymers
+		unitsPerVolume = 0.65
+		percentFilled = 0
+	}
+
+	RESOURCE 
+	{
+		name = Chemicals
+		unitsPerVolume = 0.65
+		percentFilled = 0
+	}
+}
+
+// MKS: Agroponics
+B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/MKS]
+{
+	name = USIMKSAgroponics
+	primaryColor = green
+	secondaryColor = green
+	
+	RESOURCE 
+	{
+		name = Mulch
+		unitsPerVolume = 3
+		percentFilled = 0
+	}
+	
+	RESOURCE 
+	{
+		name = Fertilizer
+		unitsPerVolume = 0.32
+		percentFilled = 0
+	}
+
+	RESOURCE 
+	{
+		name = Supplies
+		unitsPerVolume = 3.2
+		percentFilled = 0
+	}
+}
+
+// MKS:   Cultivate (S)
+B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/MKS]
+{
+	name = USIMKSCultivateS
+	primaryColor = green
+	secondaryColor = green
+	
+	RESOURCE 
+	{
+		name = Substrate
+		unitsPerVolume = 7
+		percentFilled = 0
+	}
+	
+	RESOURCE 
+	{
+		name = Water
+		unitsPerVolume = 7
+		percentFilled = 0
+	}
+
+	RESOURCE 
+	{
+		name = Fertilizer
+		unitsPerVolume = 0.1
+		percentFilled = 0
+	}
+
+	RESOURCE 
+	{
+		name = Supplies
+		unitsPerVolume = 0.7
+		percentFilled = 0
+	}
+}
+
+// MKS:   Cultivate (D)
+B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/MKS]
+{
+	name = USIMKSCultivateD
+	primaryColor = green
 	
 	RESOURCE 
 	{

--- a/Content/GameData/GrimmAerospace/GrimmModlets/B9TankTypes/USIB9TankTypes.cfg
+++ b/Content/GameData/GrimmAerospace/GrimmModlets/B9TankTypes/USIB9TankTypes.cfg
@@ -99,7 +99,7 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch,CommunityResourcePack]
 // USILS: Supplies, Mulch
 B9_TANK_TYPE:NEEDS[B9PartSwitch,USILifeSupport]
 {
-	name = USISuppliesMulch
+	name = USISupplies
 	primaryColor = blue
 	secondaryColor = ResourceColorOre
 	

--- a/Content/GameData/GrimmAerospace/GrimmModlets/B9TankTypes/USIB9TankTypes.cfg
+++ b/Content/GameData/GrimmAerospace/GrimmModlets/B9TankTypes/USIB9TankTypes.cfg
@@ -97,7 +97,7 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch,CommunityResourcePack]
 }
 
 // USILS: Supplies, Mulch
-B9_TANK_TYPE:NEEDS[B9PartSwitch,UmbraSpaceIndustries/LifeSupport]
+B9_TANK_TYPE:NEEDS[B9PartSwitch,USILifeSupport]
 {
 	name = USISuppliesMulch
 	primaryColor = blue

--- a/Content/GameData/GrimmAerospace/GrimmModlets/USIKontainersB9Patch/FlatTankB9.cfg
+++ b/Content/GameData/GrimmAerospace/GrimmModlets/USIKontainersB9Patch/FlatTankB9.cfg
@@ -82,7 +82,7 @@
 		    tankType = USIPolymers
 		}
 		
-		SUBTYPE:NEEDS[UmbraSpaceIndustries/LifeSupport]
+		SUBTYPE:NEEDS[USILifeSupport]
 		{
 		    name = tanksupplies
 		    title = Supplies // TODO LOC

--- a/Content/GameData/GrimmAerospace/GrimmModlets/USIKontainersB9Patch/FlatTankB9.cfg
+++ b/Content/GameData/GrimmAerospace/GrimmModlets/USIKontainersB9Patch/FlatTankB9.cfg
@@ -54,14 +54,12 @@
 		    tankType = USIKarbonite
 		}
 		
-		//SUBTYPE:NEEDS[XXX]
-		//{
-		//    name = tankcommodities
-		//    title = Commodities
-		//    tankType = USICommodities
-		//	
-		//	
-		//}
+		SUBTYPE:NEEDS[CommunityResourcePack]
+		{
+		    name = tankcommodities
+		    title = Commodities // TODO LOC
+		    tankType = USICommodities	
+		}
 		
 		SUBTYPE:NEEDS[CommunityResourcePack]
 		{
@@ -84,7 +82,7 @@
 		    tankType = USIPolymers
 		}
 		
-		SUBTYPE:NEEDS[USILifeSupport]
+		SUBTYPE:NEEDS[UmbraSpaceIndustries/LifeSupport]
 		{
 		    name = tanksupplies
 		    title = Supplies // TODO LOC

--- a/Content/GameData/GrimmAerospace/GrimmModlets/USIKontainersB9Patch/KontainerB9.cfg
+++ b/Content/GameData/GrimmAerospace/GrimmModlets/USIKontainersB9Patch/KontainerB9.cfg
@@ -84,18 +84,18 @@
 			}
 		}
 		
-		//SUBTYPE:NEEDS[XXX]
-		//{
-		//    name = tankcommodities
-		//    title = Commodities
-		//    tankType = USICommodities
-		//	
-		//	TEXTURE
-		//	{
-		//		texture = UmbraSpaceIndustries/Kontainers/Assets/Kontainer_05
-		//		//transform = Kontainer
-		//	}
-		//}
+		SUBTYPE:NEEDS[CommunityResourcePack]
+		{
+		    name = tankcommodities
+		    title = Commodities // TODO LOC
+		    tankType = USICommodities
+			
+			TEXTURE
+			{
+				texture = UmbraSpaceIndustries/Kontainers/Assets/Kontainer_05
+				//transform = Kontainer
+			}
+		}
 		
 		SUBTYPE:NEEDS[CommunityResourcePack]
 		{
@@ -136,7 +136,7 @@
 			}
 		}
 		
-		SUBTYPE:NEEDS[USILifeSupport]
+		SUBTYPE:NEEDS[UmbraSpaceIndustries/LifeSupport]
 		{
 		    name = tanksupplies
 		    title = Supplies // TODO LOC

--- a/Content/GameData/GrimmAerospace/GrimmModlets/USIKontainersB9Patch/KontainerB9.cfg
+++ b/Content/GameData/GrimmAerospace/GrimmModlets/USIKontainersB9Patch/KontainerB9.cfg
@@ -136,7 +136,7 @@
 			}
 		}
 		
-		SUBTYPE:NEEDS[UmbraSpaceIndustries/LifeSupport]
+		SUBTYPE:NEEDS[USILifeSupport]
 		{
 		    name = tanksupplies
 		    title = Supplies // TODO LOC

--- a/Content/GameData/GrimmAerospace/GrimmModlets/USIKontainersB9Patch/MountableSupPakB9.cfg
+++ b/Content/GameData/GrimmAerospace/GrimmModlets/USIKontainersB9Patch/MountableSupPakB9.cfg
@@ -82,7 +82,7 @@
 		    tankType = USIPolymers
 		}
 		
-		SUBTYPE:NEEDS[UmbraSpaceIndustries/LifeSupport]
+		SUBTYPE:NEEDS[USILifeSupport]
 		{
 		    name = tanksupplies
 		    title = Supplies // TODO LOC

--- a/Content/GameData/GrimmAerospace/GrimmModlets/USIKontainersB9Patch/MountableSupPakB9.cfg
+++ b/Content/GameData/GrimmAerospace/GrimmModlets/USIKontainersB9Patch/MountableSupPakB9.cfg
@@ -54,14 +54,12 @@
 		    tankType = USIKarbonite
 		}
 		
-		//SUBTYPE:NEEDS[XXX]
-		//{
-		//    name = tankcommodities
-		//    title = Commodities
-		//    tankType = USICommodities
-		//	
-		//	
-		//}
+		SUBTYPE:NEEDS[CommunityResourcePack]
+		{
+		    name = tankcommodities
+		    title = Commodities // TODO LOC
+		    tankType = USICommodities
+		}
 		
 		SUBTYPE:NEEDS[CommunityResourcePack]
 		{
@@ -84,7 +82,7 @@
 		    tankType = USIPolymers
 		}
 		
-		SUBTYPE:NEEDS[USILifeSupport]
+		SUBTYPE:NEEDS[UmbraSpaceIndustries/LifeSupport]
 		{
 		    name = tanksupplies
 		    title = Supplies // TODO LOC

--- a/Content/GameData/GrimmAerospace/GrimmModlets/USIKontainersB9Patch/RadialSupPakB9.cfg
+++ b/Content/GameData/GrimmAerospace/GrimmModlets/USIKontainersB9Patch/RadialSupPakB9.cfg
@@ -82,7 +82,7 @@
 		    tankType = USIPolymers
 		}
 		
-		SUBTYPE:NEEDS[UmbraSpaceIndustries/LifeSupport]
+		SUBTYPE:NEEDS[USILifeSupport]
 		{
 		    name = tanksupplies
 		    title = Supplies // TODO LOC

--- a/Content/GameData/GrimmAerospace/GrimmModlets/USIKontainersB9Patch/RadialSupPakB9.cfg
+++ b/Content/GameData/GrimmAerospace/GrimmModlets/USIKontainersB9Patch/RadialSupPakB9.cfg
@@ -54,14 +54,12 @@
 		    tankType = USIKarbonite
 		}
 		
-		//SUBTYPE:NEEDS[XXX]
-		//{
-		//    name = tankcommodities
-		//    title = Commodities
-		//    tankType = USICommodities
-		//	
-		//	
-		//}
+		SUBTYPE:NEEDS[CommunityResourcePack]
+		{
+		    name = tankcommodities
+		    title = Commodities
+		    tankType = USICommodities // TODO LOC
+		}
 		
 		SUBTYPE:NEEDS[CommunityResourcePack]
 		{
@@ -84,7 +82,7 @@
 		    tankType = USIPolymers
 		}
 		
-		SUBTYPE:NEEDS[USILifeSupport]
+		SUBTYPE:NEEDS[UmbraSpaceIndustries/LifeSupport]
 		{
 		    name = tanksupplies
 		    title = Supplies // TODO LOC

--- a/Content/GameData/GrimmAerospace/GrimmModlets/USIKontainersB9Patch/StowPakSupB9.cfg
+++ b/Content/GameData/GrimmAerospace/GrimmModlets/USIKontainersB9Patch/StowPakSupB9.cfg
@@ -82,7 +82,7 @@
 		    tankType = USIPolymers
 		}
 		
-		SUBTYPE:NEEDS[UmbraSpaceIndustries/LifeSupport]
+		SUBTYPE:NEEDS[USILifeSupport]
 		{
 		    name = tanksupplies
 		    title = Supplies // TODO LOC

--- a/Content/GameData/GrimmAerospace/GrimmModlets/USIKontainersB9Patch/StowPakSupB9.cfg
+++ b/Content/GameData/GrimmAerospace/GrimmModlets/USIKontainersB9Patch/StowPakSupB9.cfg
@@ -54,14 +54,12 @@
 		    tankType = USIKarbonite
 		}
 		
-		//SUBTYPE:NEEDS[XXX]
-		//{
-		//    name = tankcommodities
-		//    title = Commodities
-		//    tankType = USICommodities
-		//	
-		//	
-		//}
+		SUBTYPE:NEEDS[CommunityResourcePack]
+		{
+		    name = tankcommodities
+		    title = Commodities // TODO LOC
+		    tankType = USICommodities
+		}
 		
 		SUBTYPE:NEEDS[CommunityResourcePack]
 		{
@@ -84,7 +82,7 @@
 		    tankType = USIPolymers
 		}
 		
-		SUBTYPE:NEEDS[USILifeSupport]
+		SUBTYPE:NEEDS[UmbraSpaceIndustries/LifeSupport]
 		{
 		    name = tanksupplies
 		    title = Supplies // TODO LOC

--- a/Content/GameData/GrimmAerospace/GrimmModlets/USIMKSB9Patch/USIMKSB9Patch.cfg
+++ b/Content/GameData/GrimmAerospace/GrimmModlets/USIMKSB9Patch/USIMKSB9Patch.cfg
@@ -71,7 +71,7 @@
 			}
 		}
 
-        SUBTYPE
+        SUBTYPE:NEEDS[Karbonite]
 		{
 		    name = tankrefwatk
 		    title = Refine Water (Ker)
@@ -366,7 +366,7 @@
 		    tankType = USIMKSRefineWaterHyd
 		}
 
-        SUBTYPE
+        SUBTYPE:NEEDS[Karbonite]
 		{
 		    name = tankrefwatk
 		    title = Refine Water (Ker)


### PR DESCRIPTION
Commodities is not an actual resource, and the original tank type contains an equal amount of RareMetals and ExoticMinerals.

Edit: Also changes the tank type USISuppliesMulch to USISupplies so it will actually show up, and, appropriately, removes Mulch from it. This was very much a quick fix, so you may want to change this.